### PR TITLE
Add draggable frames with persistence

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,3 +1,12 @@
 function doGet() {
   return HtmlService.createHtmlOutputFromFile('index');
 }
+
+function getFrames() {
+  var prop = PropertiesService.getScriptProperties().getProperty('frames');
+  return prop ? JSON.parse(prop) : [];
+}
+
+function saveFrames(frames) {
+  PropertiesService.getScriptProperties().setProperty('frames', JSON.stringify(frames));
+}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html>
 <head>
   <base target="_top">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
   <style>
     body { margin: 0; font-family: Arial, sans-serif; }
     header {
@@ -22,6 +25,53 @@
     header div {
       text-align: center;
     }
+    #add-btn {
+      position: absolute;
+      right: 20px;
+      background: white;
+      color: #B31B34;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-weight: bold;
+      border-radius: 4px;
+    }
+    #add-btn:hover {
+      background: #f0f0f0;
+    }
+    #framesContainer {
+      position: relative;
+      height: calc(100vh - 120px);
+    }
+    .frame {
+      position: absolute;
+      border: 2px solid #B31B34;
+      background: white;
+      width: 200px;
+      height: 150px;
+      box-sizing: border-box;
+    }
+    .frame-header {
+      background: linear-gradient(to right, #B31B34, #531412, #459652);
+      color: white;
+      padding: 5px;
+      cursor: move;
+      font-weight: bold;
+    }
+    .frame-body {
+      padding: 10px;
+      height: calc(100% - 30px);
+      overflow: auto;
+    }
+    .resizer {
+      width: 15px;
+      height: 15px;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      cursor: se-resize;
+      background: #ddd;
+    }
     .subtitle {
       font-size: 1.2em;
     }
@@ -39,7 +89,10 @@
       <div class="small-text" id="datetime">Loading time...</div>
       <div class="small-text" id="weather">Loading weather...</div>
     </div>
+    <button id="add-btn">Add</button>
   </header>
+
+  <div id="framesContainer"></div>
 
   <script>
     function updateDateTime() {
@@ -66,6 +119,77 @@
     updateWeather();
     setInterval(updateDateTime, 1000);
     setInterval(updateWeather, 600000); // refresh weather every 10 minutes
+
+    let frames = [];
+
+    function createFrame(data) {
+      const frame = $('<div class="frame"></div>').attr('id', data.id)
+        .css({ top: data.y, left: data.x, width: data.width, height: data.height });
+      const header = $('<div class="frame-header" contenteditable="true"></div>').text(data.title);
+      const body = $('<div class="frame-body" contenteditable="true"></div>').html(data.content);
+      const resizer = $('<div class="resizer"></div>');
+      frame.append(header, body, resizer);
+      $('#framesContainer').append(frame);
+
+      frame.draggable({
+        handle: '.frame-header',
+        containment: '#framesContainer',
+        stop: function() {
+          updateFrameData(frame.attr('id'));
+          saveFrames();
+        }
+      }).resizable({
+        handles: { 'se': '.resizer' },
+        stop: function() {
+          updateFrameData(frame.attr('id'));
+          saveFrames();
+        }
+      });
+
+      header.on('blur', function() {
+        updateFrameData(frame.attr('id'));
+        saveFrames();
+      });
+
+      body.on('blur', function() {
+        updateFrameData(frame.attr('id'));
+        saveFrames();
+      });
+    }
+
+    function updateFrameData(id) {
+      const div = $('#' + id);
+      const index = frames.findIndex(f => f.id === id);
+      if (index === -1) return;
+      frames[index].x = div.position().left;
+      frames[index].y = div.position().top;
+      frames[index].width = div.outerWidth();
+      frames[index].height = div.outerHeight();
+      frames[index].title = div.find('.frame-header').text();
+      frames[index].content = div.find('.frame-body').html();
+    }
+
+    function addFrame() {
+      const id = 'frame-' + Date.now();
+      const data = { id, title: 'New Frame', content: '', x: 10, y: 10, width: 200, height: 150 };
+      frames.push(data);
+      createFrame(data);
+      saveFrames();
+    }
+
+    function renderFrames(data) {
+      frames = data;
+      frames.forEach(createFrame);
+    }
+
+    function saveFrames() {
+      google.script.run.saveFrames(frames);
+    }
+
+    $(document).ready(function() {
+      $('#add-btn').on('click', addFrame);
+      google.script.run.withSuccessHandler(renderFrames).getFrames();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include jQuery and jQuery UI
- add "Add" button in the header and container for frames
- implement draggable/resizable frames with editable title and body
- save frame layouts server-side with Google Apps Script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476fb5fc908322a3bd76aad2298d9f