### PR TITLE
Enable quick link insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ PulseHub is a Google Apps Script web application designed to serve as a central 
 
 The project consists of a simple script (`Code.gs`) and a corresponding `index.html` file served via `HtmlService`. The header displays the company logo along with real-time date, time, and weather information.
 
-Frames can be dragged from their headers and resized. Double-click a frame's title or body to edit its contents.
+Frame titles have been enlarged by 50% and centered within each header for better readability.
+
+Frames can be dragged from their headers and resized. Double-click a frame's title or body to edit its contents. When the body is already in edit mode, double-clicking again allows you to quickly insert a hyperlink on the selected text or at the cursor.
 
 To deploy, create a new Apps Script project, copy the files from the repository root, and publish as a web app.

--- a/index.html
+++ b/index.html
@@ -65,6 +65,9 @@
       cursor: move;
       font-weight: bold;
       position: relative;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
     .close-btn {
       position: absolute;
@@ -76,6 +79,7 @@
     }
     .frame-title {
       display: inline-block;
+      font-size: 1.5em;
     }
     .close-btn:hover {
       color: #ddd;
@@ -192,7 +196,20 @@
 
       body.on('dblclick', function(e) {
         e.stopPropagation();
-        $(this).attr('contenteditable', 'true').focus();
+        const editable = $(this).attr('contenteditable') === 'true';
+        if (editable) {
+          const url = prompt('Enter link URL:');
+          if (url) {
+            const sel = window.getSelection();
+            if (sel.rangeCount > 0 && !sel.isCollapsed) {
+              document.execCommand('createLink', false, url);
+            } else {
+              document.execCommand('insertHTML', false, `<a href="${url}" target="_blank">${url}</a>`);
+            }
+          }
+        } else {
+          $(this).attr('contenteditable', 'true').focus();
+        }
       });
 
       body.on('blur', function() {


### PR DESCRIPTION
## Summary
- allow hyperlink insertion when editing frame content with a second double-click
- enlarge and center frame titles in their headers
- document new link feature and larger titles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684779b17f8883228f571f25b580e8d4